### PR TITLE
Update sitelen-pona.css to make it work better with Vencord

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,13 @@ To patch your Discord to correctly render sitelen pona on desktop, we will use t
 
 First go to go to Settings, then scroll down to "Vencord", click "Themes", and then "Online Themes"
 
-Paste this link to the `sitelen-pona.css` file into the text box: https://raw.githubusercontent.com/neroist/sitelen-pona-ucsur-guide/main/css/sitelen-pona.css
+Paste this link into the text box:
 
-If the "Validator" section below shows that the theme is valid, you can now exit settings, your Discord should be properly set up to render sitelen pona!
+```
+https://raw.githubusercontent.com/neroist/sitelen-pona-ucsur-guide/main/css/sitelen-pona.css
+```
+
+If the "Validator" section below shows that the theme is valid, you can now exit settings, and your Discord should be properly set up to render sitelen pona!
 
 ### Browser
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This method does not work on macOS or mobile devices.
 
 To patch your Discord to correctly render sitelen pona on desktop, we will use the [Vencord client modification](https://vencord.dev/). Start by following the installation guide on their website to install it. After installing Vencord we need to add a CSS snippet, this is a small snippet of code that tells Vencord to use Fairfax HD or nasin nanpa when sitelen pona is present.
 
-First go to go to Settings, then scroll down to "Vencord", click "Themes", and then "Online Themes"
+First go to go to Settings, then scroll down to "Vencord", click "Themes", then "Online Themes"
 
 Paste this link into the text box:
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ This method does not work on macOS or mobile devices.
 
 To patch your Discord to correctly render sitelen pona on desktop, we will use the [Vencord client modification](https://vencord.dev/). Start by following the installation guide on their website to install it. After installing Vencord we need to add a CSS snippet, this is a small snippet of code that tells Vencord to use Fairfax HD or nasin nanpa when sitelen pona is present.
 
-First go to go to Settings, then scroll down to "Vencord", click "Themes", and press "Edit QuickCSS"
+First go to go to Settings, then scroll down to "Vencord", click "Themes", and then "Online Themes"
 
-Paste the [sitelen-pona.css](https://raw.githubusercontent.com/neroist/sitelen-pona-ucsur-guide/main/css/sitelen-pona.css) file into the text box (click the link, then press <kbd>Ctrl</kbd> + <kbd>A</kbd> then <kbd>Ctrl</kbd> + <kbd>C</kbd>. Then, paste the text into the text box.) Remember to remove the `@-moz-document domain("discord.com") {` line from the code!
+Paste this link to the `sitelen-pona.css` file into the text box: https://raw.githubusercontent.com/neroist/sitelen-pona-ucsur-guide/main/css/sitelen-pona.css
 
-Once you have pasted the code into the QuickCSS box, you can now exit settings, your Discord should be properly set up to render sitelen pona!
+If the "Validator" section below shows that the theme is valid, you can now exit settings, your Discord should be properly set up to render sitelen pona!
 
 ### Browser
 

--- a/css/sitelen-pona.css
+++ b/css/sitelen-pona.css
@@ -9,97 +9,96 @@
 @license      CC0-1.0
 ==/UserStyle== */
 
-@-moz-document domain("discord.com") {
-  :root {
-    /* set sitelen pona font vars */
-    --font-sp-mono: 'nasin-nanpa', 'Fairfax HD', 'sitelen seli kiwen mono juniko', 'sitelen seli kiwen mono juniko meso';
 
-    --font-sp: var(--font-sp-mono), 'sitelen seli kiwen juniko', 'sitelen seli kiwen juniko meso';
+:root {
+  /* set sitelen pona font vars */
+  --font-sp-mono: 'nasin-nanpa', 'Fairfax HD', 'sitelen seli kiwen mono juniko', 'sitelen seli kiwen mono juniko meso';
 
-    /* set discord fonts */
-    --font-primary: 'gg sans', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
-    
-    --font-display: 'gg sans', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
-    
-    --font-headline: 'ABC Ginto Nord', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
-    
-    --font-code: Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter', 'DejaVu Sans Mono',
-                'Bitstream Vera Sans Mono', 'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace,
-                var(--font-sp-mono);
-  }
+  --font-sp: var(--font-sp-mono), 'sitelen seli kiwen juniko', 'sitelen seli kiwen juniko meso';
 
-  :root:lang(el),
-  :root:lang(ru),
-  :root:lang(uk),
-  :root:lang(bg) {
-    --font-primary: 'gg sans', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
-    
-    --font-display: 'gg sans', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
-    
-    --font-headline: 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
-    
-    --font-code: Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter', 'DejaVu Sans Mono',
-                 'Bitstream Vera Sans Mono', 'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace,
-                 var(--font-sp-mono);
-  }
+  /* set discord fonts */
+  --font-primary: 'gg sans', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
+  
+  --font-display: 'gg sans', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
+  
+  --font-headline: 'ABC Ginto Nord', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
+  
+  --font-code: Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter', 'DejaVu Sans Mono',
+              'Bitstream Vera Sans Mono', 'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace,
+              var(--font-sp-mono);
+}
 
-  :root:lang(ko) {
-    --font-primary: 'gg sans', 'Apple SD Gothic Neo', NanumBarunGothic, '맑은 고딕', 'Malgun Gothic', Gulim, 굴림, Dotum,
-                    돋움, 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
-    
-    --font-display: 'gg sans', 'Apple SD Gothic Neo', NanumBarunGothic, '맑은 고딕', 'Malgun Gothic', Gulim, 굴림, Dotum,
-                    돋움, 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
-    
-    --font-headline: 'ABC Ginto Nord', 'Apple SD Gothic Neo', NanumBarunGothic, '맑은 고딕', 'Malgun Gothic', Gulim, 굴림,
-                     Dotum, 돋움, 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
-    
-    --font-code: Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter', 'DejaVu Sans Mono',
-                 'Bitstream Vera Sans Mono', 'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace,
-                 var(--font-sp-mono);
-  }
+:root:lang(el),
+:root:lang(ru),
+:root:lang(uk),
+:root:lang(bg) {
+  --font-primary: 'gg sans', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
+  
+  --font-display: 'gg sans', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
+  
+  --font-headline: 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
+  
+  --font-code: Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter', 'DejaVu Sans Mono',
+               'Bitstream Vera Sans Mono', 'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace,
+               var(--font-sp-mono);
+}
 
-  :root:lang(ja) {
-    --font-primary: 'gg sans', 'Hiragino Sans', 'ヒラギノ角ゴ ProN W3', 'Hiragino Kaku Gothic ProN', メイリオ, Meiryo,
-                    Osaka, 'MS PGothic', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
-    
-    --font-display: 'gg sans', 'Hiragino Sans', 'ヒラギノ角ゴ ProN W3', 'Hiragino Kaku Gothic ProN', メイリオ, Meiryo,
-                    Osaka, 'MS PGothic', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
-    
-    --font-headline: 'ABC Ginto Nord', 'Hiragino Sans', 'ヒラギノ角ゴ ProN W3', 'Hiragino Kaku Gothic ProN', メイリオ,
-                     Meiryo, Osaka, 'MS PGothic', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
-    
-    --font-code: Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter', 'DejaVu Sans Mono',
-                 'Bitstream Vera Sans Mono', 'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace,
-                 var(--font-sp-mono);
-  }
+:root:lang(ko) {
+  --font-primary: 'gg sans', 'Apple SD Gothic Neo', NanumBarunGothic, '맑은 고딕', 'Malgun Gothic', Gulim, 굴림, Dotum,
+                  돋움, 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
+  
+  --font-display: 'gg sans', 'Apple SD Gothic Neo', NanumBarunGothic, '맑은 고딕', 'Malgun Gothic', Gulim, 굴림, Dotum,
+                  돋움, 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
+  
+  --font-headline: 'ABC Ginto Nord', 'Apple SD Gothic Neo', NanumBarunGothic, '맑은 고딕', 'Malgun Gothic', Gulim, 굴림,
+                   Dotum, 돋움, 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
+  
+  --font-code: Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter', 'DejaVu Sans Mono',
+               'Bitstream Vera Sans Mono', 'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace,
+               var(--font-sp-mono);
+}
 
-  :root:lang(zh-CN) {
-    --font-primary: 'gg sans', 'Microsoft YaHei New', 微软雅黑, 'Microsoft Yahei', 'Microsoft JhengHei', 宋体, SimSun,
-                    'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
-    
-    --font-display: 'gg sans', 'Microsoft YaHei New', 微软雅黑, 'Microsoft Yahei', 'Microsoft JhengHei', 宋体, SimSun,
-                    'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
-    
-    --font-headline: 'ABC Ginto Nord', 'Microsoft YaHei New', 微软雅黑, 'Microsoft Yahei', 'Microsoft JhengHei', 宋体,
-                     SimSun, 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
-    
-    --font-code: Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter', 'DejaVu Sans Mono',
-                 'Bitstream Vera Sans Mono', 'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace,
-                 var(--font-sp-mono);
-  }
+:root:lang(ja) {
+  --font-primary: 'gg sans', 'Hiragino Sans', 'ヒラギノ角ゴ ProN W3', 'Hiragino Kaku Gothic ProN', メイリオ, Meiryo,
+                  Osaka, 'MS PGothic', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
+  
+  --font-display: 'gg sans', 'Hiragino Sans', 'ヒラギノ角ゴ ProN W3', 'Hiragino Kaku Gothic ProN', メイリオ, Meiryo,
+                  Osaka, 'MS PGothic', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
+  
+  --font-headline: 'ABC Ginto Nord', 'Hiragino Sans', 'ヒラギノ角ゴ ProN W3', 'Hiragino Kaku Gothic ProN', メイリオ,
+                   Meiryo, Osaka, 'MS PGothic', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
+  
+  --font-code: Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter', 'DejaVu Sans Mono',
+               'Bitstream Vera Sans Mono', 'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace,
+               var(--font-sp-mono);
+}
 
-  :root:lang(zh-TW) {
-    --font-primary: 'gg sans', 'Microsoft JhengHei', 微軟正黑體, 'Microsoft JhengHei UI', 'Microsoft YaHei', 微軟雅黑,
-                    宋体, SimSun, 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
-    
-    --font-display: 'gg sans', 'Microsoft JhengHei', 微軟正黑體, 'Microsoft JhengHei UI', 'Microsoft YaHei', 微軟雅黑,
-                    宋体, SimSun, 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
-    
-    --font-headline: 'ABC Ginto Nord', 'Microsoft JhengHei', 微軟正黑體, 'Microsoft JhengHei UI', 'Microsoft YaHei',
-                     微軟雅黑, 宋体, SimSun, 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
-    
-    --font-code: Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter', 'DejaVu Sans Mono',
-                 'Bitstream Vera Sans Mono', 'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace,
-                 var(--font-sp-mono);
-  }
+:root:lang(zh-CN) {
+  --font-primary: 'gg sans', 'Microsoft YaHei New', 微软雅黑, 'Microsoft Yahei', 'Microsoft JhengHei', 宋体, SimSun,
+                  'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
+  
+  --font-display: 'gg sans', 'Microsoft YaHei New', 微软雅黑, 'Microsoft Yahei', 'Microsoft JhengHei', 宋体, SimSun,
+                  'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
+  
+  --font-headline: 'ABC Ginto Nord', 'Microsoft YaHei New', 微软雅黑, 'Microsoft Yahei', 'Microsoft JhengHei', 宋体,
+                   SimSun, 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
+  
+  --font-code: Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter', 'DejaVu Sans Mono',
+               'Bitstream Vera Sans Mono', 'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace,
+               var(--font-sp-mono);
+}
+
+:root:lang(zh-TW) {
+  --font-primary: 'gg sans', 'Microsoft JhengHei', 微軟正黑體, 'Microsoft JhengHei UI', 'Microsoft YaHei', 微軟雅黑,
+                  宋体, SimSun, 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
+  
+  --font-display: 'gg sans', 'Microsoft JhengHei', 微軟正黑體, 'Microsoft JhengHei UI', 'Microsoft YaHei', 微軟雅黑,
+                  宋体, SimSun, 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
+  
+  --font-headline: 'ABC Ginto Nord', 'Microsoft JhengHei', 微軟正黑體, 'Microsoft JhengHei UI', 'Microsoft YaHei',
+                   微軟雅黑, 宋体, SimSun, 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif, var(--font-sp);
+  
+  --font-code: Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter', 'DejaVu Sans Mono',
+               'Bitstream Vera Sans Mono', 'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace,
+               var(--font-sp-mono);
 }


### PR DESCRIPTION
The README used to have instructions for removing a certain line in sitelen-pona.css before pasting it into QuickCSS. As far as I can tell, it is used in no other place, so we can just remove this line in the file itself.

With this change, it is also possible to just use Vencord's Online Themes, which is much easier for the user to install.