### PR TITLE
Fix Espanso packages and add instructions to README on toggling Espanso

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,16 +260,20 @@ nasin:
 
 3. Copy or move the file to Espanso packages folder
 
-	- Windows: `C:\Users\<user>\AppData\Roaming\espanso\match\packages`
+    - Windows: `C:\Users\<user>\AppData\Roaming\espanso\match\packages`
 	  - (<kbd>Win</kbd>+<kbd>R</kbd>, type `%appdata%` to get to `\Roaming`
 
     - macOS: `/Users/<user>/Library/Preferences/espanso/match/packages`
 	
     - Linux: `~/.config/espanso/match/packages`
 
-4. Start Espanso
+4. From where you've found your Espanso packages folder (`<wherever>/espanso/match/packages`), navigate to `<wherever>/espanso/config` and open the file `default.yml` in a text editor
 
-5. Start writing!
+5. On a new line, paste the text `toggle_key: RIGHT_ALT`, then save your changes and exit
+
+6. Start Espanso
+
+7. Start writing! *(When you want to toggle Espanso on/off, double tap <kbd>Alt</kbd> on the right side of your keyboard!)*
 
     - A table for triggers -> words can be found on sona.pona.la, [here](https://sona.pona.la/wiki/Wakalito), with a few modifications listed below. This is for the first config file, `wakalito-7-3-2-ucsur.yml`.
 

--- a/sitelen-pona-espanso.yml
+++ b/sitelen-pona-espanso.yml
@@ -3,670 +3,504 @@
 
 matches:
   # punctuation etc
-  - triggers: ["zz", "  "]
+  - triggers: ["zz ", "   "]
     replace: "　" # ! changed to logograph fullwidth space
-    word: true
 
-  - trigger: "-"
+  - trigger: "- "
     replace: "‍" # ! changed to zero width non joiner
-    word: true
 
-  - trigger: "^"
+  - trigger: "^ "
     replace: "󱦕" # ! changed to stacking joiner
-    word: true
 
-  - trigger: "*"
+  - trigger: "* "
     replace: "󱦖" # ! changed to scaling joiner
-    word: true
 
-  - trigger: ":"
+  - trigger: ": "
     replace: "󱦝" # ! changed to sp colon
-    word: true
 
-  - trigger: "."
+  - trigger: ". "
     replace: "󱦜" # ! changed to sp full stop 
-    word: true
 
-  - trigger: "["
+  - trigger: "[ "
     replace: "󱦐" # ! changed to cartouche start
-    word: true
 
-  - trigger: "]"
+  - trigger:  "] "
     replace: "󱦑" # ! changed to cartouche end
-    word: true
 
-  - trigger: "<"
+  - trigger: "< "
     replace: "「" # ! changed to cjk start quote
-    word: true
 
-  - trigger: ">"
+  - trigger: "> "
     replace: "」" # ! changed to cjk end quote
-    word: true
 
-  - trigger: "("
+  - trigger: "( "
     replace: "󱦗" # ! changed to "start left-combining (normal) long glyph"
-    word: true
 
-  - trigger: ")"
+  - trigger: ") "
     replace: "󱦘" # ! changed to "end left-combining (normal) long glyph"  
-    word: true
 
-  - trigger: "{"
+  - trigger: "{ "
     replace: "󱦚" # ! changed to "start right-combining (reversed) long glyph"
-    word: true
 
-  - trigger: "}"
+  - trigger: "} "
     replace: "󱦛" # ! changed to "end right-combining (reversed) long glyph" 
-    word: true
 
   # contractions
-  - triggers: ["msa", "misonala", "misonaala"]
+  - triggers: ["msa ", "misonala ", "misonaala "]
     replace: "󱤴󱥡󱤂"
-    word: true
 
   # pu
-  - trigger: "a"
+  - trigger: "a "
     replace: "󱤀"
-    word: true
 
-  - trigger: "aaa"
+  - trigger: "aaa "
     replace: "󱤀󱤀󱤀"
-    word: true
 
-  - trigger: "akesi"
+  - trigger: "akesi "
     replace: "󱤁"
-    word: true
 
-  - trigger: "ala"
+  - trigger: "ala "
     replace: "󱤂"
-    word: true
 
-  - trigger: "alasa"
+  - trigger: "alasa "
     replace: "󱤃"
-    word: true
 
-  - triggers: ["ale", "ali"]
+  - triggers: ["ale ", "ali "]
     replace: "󱤄"
-    word: true
 
-  - trigger: "anpa"
+  - trigger: "anpa "
     replace: "󱤅"
-    word: true
 
-  - trigger: "ante"
+  - trigger: "ante "
     replace: "󱤆"
-    word: true
 
-  - trigger: "anu"
+  - trigger: "anu "
     replace: "󱤇"
-    word: true
 
-  - trigger: "awen"
+  - trigger: "awen "
     replace: "󱤈"
-    word: true
 
-  - trigger: "e"
+  - trigger: "e "
     replace: "󱤉"
-    word: true
 
-  - trigger: "en"
+  - trigger: "en "
     replace: "󱤊"
-    word: true
 
-  - trigger: "esun"
+  - trigger: "esun "
     replace: "󱤋"
-    word: true
 
-  - trigger: "ijo"
+  - trigger: "ijo "
     replace: "󱤌"
-    word: true
 
-  - trigger: "ike"
+  - trigger: "ike "
     replace: "󱤍"
-    word: true
 
-  - trigger: "ilo"
+  - trigger: "ilo "
     replace: "󱤎"
-    word: true
 
-  - trigger: "insa"
+  - trigger: "insa "
     replace: "󱤏"
-    word: true
 
-  - trigger: "jaki"
+  - trigger: "jaki "
     replace: "󱤐"
-    word: true
 
-  - trigger: "jan"
+  - trigger: "jan "
     replace: "󱤑"
-    word: true
 
-  - trigger: "jelo"
+  - trigger: "jelo "
     replace: "󱤒"
-    word: true
 
-  - trigger: "jo"
+  - trigger: "jo "
     replace: "󱤓"
-    word: true
 
-  - trigger: "kala"
+  - trigger: "kala "
     replace: "󱤔"
-    word: true
 
-  - trigger: "kalama"
+  - trigger: "kalama "
     replace: "󱤕"
-    word: true
 
-  - trigger: "kama"
+  - trigger: "kama "
     replace: "󱤖"
-    word: true
 
-  - trigger: "kasi"
+  - trigger: "kasi "
     replace: "󱤗"
-    word: true
 
-  - trigger: "ken"
+  - trigger: "ken "
     replace: "󱤘"
-    word: true
 
-  - triggers: ["kepeken", "kepen", "kpkn"]
+  - triggers: ["kepeken ", "kepen ", "kpkn "]
     replace: "󱤙"
-    word: true
 
-  - trigger: "kili"
+  - trigger: "kili "
     replace: "󱤚"
-    word: true
 
-  - trigger: "kin"
+  - trigger: "kin "
     replace: "󱥹"
-    word: true
 
-  - trigger: "kiwen"
+  - trigger: "kiwen "
     replace: "󱤛"
-    word: true
 
-  - trigger: "ko"
+  - trigger: "ko "
     replace: "󱤜"
-    word: true
 
-  - trigger: "kon"
+  - trigger: "kon "
     replace: "󱤝"
-    word: true
 
-  - trigger: "kule"
+  - trigger: "kule "
     replace: "󱤞"
-    word: true
 
-  - trigger: "kulupu"
+  - trigger: "kulupu "
     replace: "󱤟"
-    word: true
 
-  - trigger: "kute"
+  - trigger: "kute "
     replace: "󱤠"
-    word: true
 
-  - trigger: "la"
+  - trigger: "la "
     replace: "󱤡"
-    word: true
 
-  - trigger: "lape"
+  - trigger: "lape "
     replace: "󱤢"
-    word: true
 
-  - trigger: "laso"
+  - trigger: "laso "
     replace: "󱤣"
-    word: true
 
-  - trigger: "lawa"
+  - trigger: "lawa "
     replace: "󱤤"
-    word: true
 
-  - trigger: "len"
+  - trigger: "len "
     replace: "󱤥"
-    word: true
 
-  - trigger: "lete"
+  - trigger: "lete "
     replace: "󱤦"
-    word: true
 
-  - trigger: "li"
+  - trigger: "li "
     replace: "󱤧"
-    word: true
 
-  - trigger: "lili"
+  - trigger: "lili "
     replace: "󱤨"
-    word: true
 
-  - trigger: "linja"
+  - trigger: "linja "
     replace: "󱤩"
-    word: true
 
-  - trigger: "lipu"
+  - trigger: "lipu "
     replace: "󱤪"
-    word: true
 
-  - trigger: "loje"
+  - trigger: "loje "
     replace: "󱤫"
-    word: true
 
-  - trigger: "lon"
+  - trigger: "lon "
     replace: "󱤬"
-    word: true
 
-  - trigger: "luka"
+  - trigger: "luka "
     replace: "󱤭"
-    word: true
 
-  - trigger: "lukin"
+  - trigger: "lukin "
     replace: "󱤮"
-    word: true
 
-  - trigger: "oko"
+  - trigger: "oko "
     replace: "󱥺"
-    word: true
 
-  - trigger: "lupa"
+  - trigger: "lupa "
     replace: "󱤯"
-    word: true
 
-  - trigger: "ma"
+  - trigger: "ma "
     replace: "󱤰"
-    word: true
 
-  - trigger: "mama"
+  - trigger: "mama "
     replace: "󱤱"
-    word: true
 
-  - trigger: "mani"
+  - trigger: "mani "
     replace: "󱤲"
-    word: true
 
-  - trigger: "meli"
+  - trigger: "meli "
     replace: "󱤳"
-    word: true
 
-  - trigger: "mi"
+  - trigger: "mi "
     replace: "󱤴"
-    word: true
 
-  - trigger: "mije"
+  - trigger: "mije "
     replace: "󱤵"
-    word: true
 
-  - trigger: "moku"
+  - trigger: "moku "
     replace: "󱤶"
-    word: true
 
-  - trigger: "moli"
+  - trigger: "moli "
     replace: "󱤷"
-    word: true
 
-  - trigger: "monsi"
+  - trigger: "monsi "
     replace: "󱤸"
-    word: true
 
-  - trigger: "mu"
+  - trigger: "mu "
     replace: "󱤹"
-    word: true
 
-  - trigger: "mun"
+  - trigger: "mun "
     replace: "󱤺"
-    word: true
 
-  - trigger: "musi"
+  - trigger: "musi "
     replace: "󱤻"
-    word: true
 
-  - trigger: "mute"
+  - trigger: "mute "
     replace: "󱤼"
-    word: true
 
-  - trigger: "namako"
+  - trigger: "namako "
     replace: "󱥸"
-    word: true
 
-  - trigger: "nanpa"
+  - trigger: "nanpa "
     replace: "󱤽"
-    word: true
 
-  - trigger: "nasa"
+  - trigger: "nasa "
     replace: "󱤾"
-    word: true
 
-  - trigger: "nasin"
+  - trigger: "nasin "
     replace: "󱤿"
-    word: true
 
-  - trigger: "nena"
+  - trigger: "nena "
     replace: "󱥀"
-    word: true
 
-  - trigger: "ni"
+  - trigger: "ni "
     replace: "󱥁"
-    word: true
 
-  - trigger: "nimi"
+  - trigger: "nimi "
     replace: "󱥂"
-    word: true
 
-  - trigger: "noka"
+  - trigger: "noka "
     replace: "󱥃"
-    word: true
 
-  - trigger: "o"
+  - trigger: "o "
     replace: "󱥄"
-    word: true
 
-  - trigger: "olin"
+  - trigger: "olin "
     replace: "󱥅"
-    word: true
 
-  - trigger: "ona"
+  - trigger: "ona "
     replace: "󱥆"
-    word: true
 
-  - trigger: "open"
+  - trigger: "open "
     replace: "󱥇"
-    word: true
 
-  - trigger: "pakala"
+  - trigger: "pakala "
     replace: "󱥈"
-    word: true
 
-  - trigger: "pali"
+  - trigger: "pali "
     replace: "󱥉"
-    word: true
 
-  - trigger: "palisa"
+  - trigger: "palisa "
     replace: "󱥊"
-    word: true
 
-  - trigger: "pan"
+  - trigger: "pan "
     replace: "󱥋"
-    word: true
 
-  - trigger: "pana"
+  - trigger: "pana "
     replace: "󱥌"
-    word: true
 
-  - trigger: "pi"
+  - trigger: "pi "
     replace: "󱥍"
-    word: true
 
-  - trigger: "pilin"
+  - trigger: "pilin "
     replace: "󱥎"
-    word: true
 
-  - trigger: "pimeja"
+  - trigger: "pimeja "
     replace: "󱥏"
-    word: true
 
-  - trigger: "pini"
+  - trigger: "pini "
     replace: "󱥐"
-    word: true
 
-  - trigger: "pipi"
+  - trigger: "pipi "
     replace: "󱥑"
-    word: true
 
-  - trigger: "poka"
+  - trigger: "poka "
     replace: "󱥒"
-    word: true
 
-  - trigger: "poki"
+  - trigger: "poki "
     replace: "󱥓"
-    word: true
 
-  - trigger: "pona"
+  - trigger: "pona "
     replace: "󱥔"
-    word: true
 
-  - trigger: "pu"
+  - trigger: "pu "
     replace: "󱥕"
-    word: true
 
-  - trigger: "sama"
+  - trigger: "sama "
     replace: "󱥖"
-    word: true
 
-  - trigger: "seli"
+  - trigger: "seli "
     replace: "󱥗"
-    word: true
 
-  - trigger: "selo"
+  - trigger: "selo "
     replace: "󱥘"
-    word: true
 
-  - trigger: "seme"
+  - trigger: "seme "
     replace: "󱥙"
-    word: true
 
-  - trigger: "sewi"
+  - trigger: "sewi "
     replace: "󱥚"
-    word: true
 
-  - trigger: "sijelo"
+  - trigger: "sijelo "
     replace: "󱥛"
-    word: true
 
-  - trigger: "sike"
+  - trigger: "sike "
     replace: "󱥜"
-    word: true
 
-  - trigger: "sin"
+  - trigger: "sin "
     replace: "󱥝"
-    word: true
 
-  - trigger: "sina"
+  - trigger: "sina "
     replace: "󱥞"
-    word: true
 
-  - trigger: "sinpin"
+  - trigger: "sinpin "
     replace: "󱥟"
-    word: true
 
-  - trigger: "sitelen"
+  - trigger: "sitelen "
     replace: "󱥠"
-    word: true
 
-  - trigger: "sona"
+  - trigger: "sona "
     replace: "󱥡"
-    word: true
 
-  - trigger: "soweli"
+  - trigger: "soweli "
     replace: "󱥢"
-    word: true
 
-  - trigger: "suli"
+  - trigger: "suli "
     replace: "󱥣"
-    word: true
 
-  - trigger: "suno"
+  - trigger: "suno "
     replace: "󱥤"
-    word: true
 
-  - trigger: "supa"
+  - trigger: "supa "
     replace: "󱥥"
-    word: true
 
-  - trigger: "suwi"
+  - trigger: "suwi "
     replace: "󱥦"
-    word: true
 
-  - trigger: "tan"
+  - trigger: "tan "
     replace: "󱥧"
-    word: true
 
-  - trigger: "taso"
+  - trigger: "taso "
     replace: "󱥨"
-    word: true
 
-  - trigger: "tawa"
+  - trigger: "tawa "
     replace: "󱥩"
-    word: true
 
-  - trigger: "telo"
+  - trigger: "telo "
     replace: "󱥪"
-    word: true
 
-  - trigger: "tenpo"
+  - trigger: "tenpo "
     replace: "󱥫"
-    word: true
 
-  - trigger: "toki"
+  - trigger: "toki "
     replace: "󱥬"
-    word: true
 
-  - trigger: "tomo"
+  - trigger: "tomo "
     replace: "󱥭"
-    word: true
 
-  - trigger: "tu"
+  - trigger: "tu "
     replace: "󱥮"
-    word: true
 
-  - trigger: "unpa"
+  - trigger: "unpa "
     replace: "󱥯"
-    word: true
 
-  - trigger: "uta"
+  - trigger: "uta "
     replace: "󱥰"
-    word: true
 
-  - trigger: "utala"
+  - trigger: "utala "
     replace: "󱥱"
-    word: true
 
-  - trigger: "walo"
+  - trigger: "walo "
     replace: "󱥲"
-    word: true
 
-  - trigger: "wan"
+  - trigger: "wan "
     replace: "󱥳"
-    word: true
 
-  - trigger: "waso"
+  - trigger: "waso "
     replace: "󱥴"
-    word: true
 
-  - trigger: "wawa"
+  - trigger: "wawa "
     replace: "󱥵"
-    word: true
 
-  - trigger: "weka"
+  - trigger: "weka "
     replace: "󱥶"
-    word: true
 
-  - trigger: "wile"
+  - trigger: "wile "
     replace: "󱥷"
-    word: true
 
   # ku suli
-  - trigger: "tonsi"
+  - trigger: "tonsi "
     replace: "󱥾"
-    word: true
 
-  - trigger: "monsuta"
+  - trigger: "monsuta "
     replace: "󱥽"
-    word: true
 
-  - triggers: ["kije", "kijete", "kijetesantakalu"]
+  - triggers: ["kije ", "kijete ", "kijetesantakalu "]
     replace: "󱦀"
-    word: true
 
-  - trigger: "leko"
+  - trigger: "leko "
     replace: "󱥼"
-    word: true
 
-  - trigger: "kipisi"
+  - trigger: "kipisi "
     replace: "󱥻"
-    word: true
 
-  - trigger: "apeja"
+  - trigger: "apeja "
     replace: "󱦡"
-    word: true
 
-  - trigger: "jasima"
+  - trigger: "jasima "
     replace: "󱥿"
-    word: true
 
-  - triggers: ["oke", "oki", "ke"]
+  - triggers: ["oke ", "oki ", "ke "]
     replace: "󿫤"
-    word: true
 
-  - trigger: "n"
+  - trigger: "n "
     replace: "󱦆"
-    word: true
 
-  - trigger: "soko"
+  - trigger: "soko "
     replace: "󱦁"
-    word: true
 
-  - trigger: "meso"
+  - trigger: "meso "
     replace: "󱦂"
-    word: true
 
-  - trigger: "epiku"
+  - trigger: "epiku "
     replace: "󱦃"
-    word: true
 
-  - trigger: "kokosila"
+  - trigger: "kokosila "
     replace: "󱦄"
-    word: true
 
-  - trigger: "lanpan"
+  - trigger: "lanpan "
     replace: "󱦅"
-    word: true
 
-  - trigger: "misikeke"
+  - trigger: "misikeke "
     replace: "󱦇"
-    word: true
 
-  - trigger: "ku"
+  - trigger: "ku "
     replace: "󱦈"
-    word: true
 
-  - trigger: "su"
+  - trigger: "su "
     replace: "󿬯"
-    word: true
 
   # (select) ku lili
-  - trigger: "isipin"
+  - trigger: "isipin "
     replace: "󿫀"
-    word: true
 
-  - trigger: "kapesi"
+  - trigger: "kapesi "
     replace: "󿫁"
-    word: true
 
-  - trigger: "kiki"
+  - trigger: "kiki "
     replace: "󿫃"
-    word: true
 
-  - triggers: ["linluwi", "linuwi"]
+  - triggers: ["linluwi ", "linuwi "]
     replace: "󿫄"
-    word: true
 
-  - trigger: "mulapisu"
+  - trigger: "mulapisu "
     replace: "󿫈"
-    word: true
 
-  - trigger: "pake"
+  - trigger: "pake "
     replace: "󱦠"
-    word: true
 
-  - trigger: "Pingo"
+  - trigger: "Pingo "
     replace: "󿫽"
-    word: true
 
-  - trigger: "powe"
+  - trigger: "powe "
     replace: "󱦣"
-    word: true
 
-  - trigger: "unu"
+  - trigger: "unu "
     replace: "󿫊"
-    word: true
 
-  - trigger: "wa"
+  - trigger: "wa "
     replace: "󿫋"
-    word: true

--- a/wakalito-7-3-2-ucsur.yml
+++ b/wakalito-7-3-2-ucsur.yml
@@ -3,685 +3,517 @@
 
 matches:
   # punctuation etc
-  - triggers: ["666", "   "]
+  - triggers: ["666 ", "    "]
     replace: "　" # ! changed to logograph fullwidth space
     
-  - trigger: "aa"
+  - trigger: "aa "
     replace: "‍" # ! changed to zero width non joiner
-    word: true
  
-  - trigger: "gg"
+  - trigger: "gg "
     replace: "󱦕" # ! changed to stacking joiner
-    word: true
   
-  - trigger: "hh"
+  - trigger: "hh "
     replace: "󱦖" # ! changed to scaling joiner
-    word: true
 
-  - trigger: "6y"
+  - trigger: "6y "
     replace: "󱦝" # ! changed to sp colon
-    word: true
     
-  - trigger: "3"
-    replace: "󱦜" # ! changed to sp full stop
-    word: true 
+  - trigger: "3 "
+    replace: "󱦜" # ! changed to sp full stop 
   
-  - trigger: "c1"
+  - trigger: "c1 "
     replace: "󱦐" # ! changed to cartouche start
-    word: true
 
-  - trigger: "c2"
+  - trigger: "c2 "
     replace: "󱦑" # ! changed to cartouche end
-    word: true
 
-  - trigger: "q1"
+  - trigger: "q1 "
     replace: "「" # ! changed to cjk start quote
-    word: true
 
-  - trigger: "q2"
+  - trigger: "q2 "
     replace: "」" # ! changed to cjk end quote
-    word: true
   
-  - trigger: "b1"
+  - trigger: "b1 "
     replace: "󱦗" # ! changed to "start left-combining (normal) long glyph"
-    word: true
 
-  - trigger: "b2"
-    replace: "󱦘" # ! changed to "end left-combining (normal) long glyph"
-    word: true  
+  - trigger: "b2 "
+    replace: "󱦘" # ! changed to "end left-combining (normal) long glyph"  
   
-  - trigger: "d1"
+  - trigger: "d1 "
     replace: "󱦚" # ! changed to "start right-combining (reversed) long glyph"
-    word: true
   
-  - trigger: "d2"
-    replace: "󱦛" # ! changed to "end right-combining (reversed) long glyph"
-    word: true 
+  - trigger: "d2 "
+    replace: "󱦛" # ! changed to "end right-combining (reversed) long glyph" 
 
   # contractions
-  - trigger: "wd4"
+  - trigger: "wd4 "
     replace: "󱤴󱥡󱤂"
-    word: true
     
   # emoticons
-  - triggers: ["a1", "ay", "at"]
+  - triggers: ["a1 ", "ay ", "at "]
     replace: ":)"
-    word: true
 
-  - triggers: ["a6", "a5"]
+  - triggers: ["a6 ", "a5 "]
     replace: ":("
-    word: true
 
-  - triggers: ["a2", "aw"]
-    replace: ":|"
-    word: true 
+  - triggers: ["a2 ", "aw "]
+    replace: ":|" 
 
-  - trigger: "a5"
+  - trigger: "a5 "
     replace: ":v"
-    word: true
 
   # pu
-  - triggers: ["we3", "w33"]
+  - triggers: ["we3 ", "w33 "]
     replace: "󱤀"
-    word: true
     
-  - trigger : "w3w3"
+  - trigger : "w3w3 "
     replace: "󱤀󱤀󱤀"
     
-  - triggers: ["33222e", "e22233"]
+  - triggers: ["33222e ", "e22233 "]
     replace: "󱤁"
-    word: true
 
-  - trigger: "4r"
+  - trigger: "4r "
     replace: "󱤂"
-    word: true
 
-  - triggers: ["w12", "w12r", "1w2", "1w2r"]
+  - triggers: ["w12 ", "w12r ", "1w2 ", "1w2r "]
     replace: "󱤃"
-    word: true
 
-  - trigger: "e1"
+  - trigger: "e1 "
     replace: "󱤄"
-    word: true
 
-  - trigger: "3s3"
+  - trigger: "3s3 "
     replace: "󱤅"
-    word: true
 
-  - trigger: "r4"
+  - trigger: "r4 "
     replace: "󱤆"
-    word: true
 
-  - trigger: "4w"
+  - trigger: "4w "
     replace: "󱤇"
-    word: true
 
-  - trigger: "2r2"
+  - trigger: "2r2 "
     replace: "󱤈"
-    word: true
 
-  - trigger: "rr"
+  - trigger: "rr "
     replace: "󱤉"
-    word: true
 
-  - trigger: "w2w"
+  - trigger: "w2w "
     replace: "󱤊"
-    word: true
 
-  - trigger: "tw5"
+  - trigger: "tw5 "
     replace: "󱤋"
-    word: true
 
-  - trigger: "e"
+  - trigger: "e "
     replace: "󱤌"
-    word: true
 
-  - trigger: "5"
+  - trigger: "5 "
     replace: "󱤍"
-    word: true
 
-  - triggers: ["dw", "wd"]
+  - triggers: ["dw ", "wd "]
     replace: "󱤎"
-    word: true
 
-  - triggers: ["s33", "33s33"]
+  - triggers: ["s33 ", "33s33 "]
     replace: "󱤏"
-    word: true
 
-  - trigger: "qqq"
+  - trigger: "qqq "
     replace: "󱤐"
-    word: true
 
-  - trigger: "er"
+  - trigger: "er "
     replace: "󱤑"
-    word: true
 
-  - trigger: "edr2"
+  - trigger: "edr2 "
     replace: "󱤒"
-    word: true
 
-  - trigger: "et2"
+  - trigger: "et2 "
     replace: "󱤓"
-    word: true
 
-  - trigger: "re"
+  - trigger: "re "
     replace: "󱤔"
-    word: true
 
-  - trigger: "t2f"
+  - trigger: "t2f "
     replace: "󱤕"
-    word: true
 
-  - trigger: "22r"
+  - trigger: "22r "
     replace: "󱤖"
-    word: true
 
-  - triggers: ["eew", "wee", "ewe"]
+  - triggers: ["eew ", "wee ", "ewe "]
     replace: "󱤗"
-    word: true
 
-  - trigger: "ww4"
+  - trigger: "ww4 "
     replace: "󱤘"
-    word: true
 
-  - triggers: ["dwq", "wdq", "qwd", "qdw", "dqw"]
+  - triggers: ["dwq ", "wdq ", "qwd ", "qdw ", "dqw "]
     replace: "󱤙"
-    word: true
 
-  - triggers: ["55tw", "5t5w"]
+  - triggers: ["55tw ", "5t5w "]
     replace: "󱤚"
-    word: true
 
-  - triggers: ["w4rw", "w4r"]
+  - triggers: ["w4rw ", "w4r "]
     replace: "󱥹"
-    word: true
 
-  - triggers: ["4r2", "4ww2"]
+  - triggers: ["4r2 ", "4ww2 "]
     replace: "󱤛"
-    word: true
 
-  - triggers: ["5et", "te5"]
+  - triggers: ["5et ", "te5 "]
     replace: "󱤜"
-    word: true
 
-  - triggers: ["4r4r", "1111", "r4r4"]
+  - triggers: ["4r4r ", "1111 ", "r4r4 "]
     replace: "󱤝"
-    word: true
 
-  - triggers: ["r2", "r222"]
+  - triggers: ["r2 ", "r222 "]
     replace: "󱤞"
-    word: true
 
-  - trigger: "eee"
+  - trigger: "eee "
     replace: "󱤟"
-    word: true
 
-  - triggers: ["13", "31"]
+  - triggers: ["13 ", "31 "]
     replace: "󱤠"
-    word: true
 
-  - trigger: "1"
+  - trigger: "1 "
     replace: "󱤡"
-    word: true
 
-  - trigger: "22e"
+  - trigger: "22e "
     replace: "󱤢"
-    word: true
 
-  - triggers: ["eewr2", "weer2", "wee2r", "eew2r", "r2wee", "r2ewe"]
+  - triggers: ["eewr2 ", "weer2 ", "wee2r ", "eew2r ", "r2wee ", "r2ewe "]
     replace: "󱤣"
-    word: true
 
-  - trigger: "e2"
+  - trigger: "e2 "
     replace: "󱤤"
-    word: true
 
-  - triggers: ["dwww", "wwwd"]
+  - triggers: ["dwww ", "wwwd "]
     replace: "󱤥"
-    word: true
 
-  - triggers: ["42r", "r42"]
+  - triggers: ["42r ", "r42 "]
     replace: "󱤦"
-    word: true
 
-  - trigger: "r"
+  - trigger: "r "
     replace: "󱤧"
-    word: true
 
-  - trigger: "4"
+  - trigger: "4 "
     replace: "󱤨"
-    word: true
 
-  - triggers: ["t5", "5t"]
+  - triggers: ["t5 ", "5t "]
     replace: "󱤩"
-    word: true
 
-  - trigger: "d"
+  - trigger: "d "
     replace: "󱤪"
-    word: true
 
-  - triggers: ["t2r2", "2tr2", "r2t2", "2rt2", "r22t", "2r2t"]
+  - triggers: ["t2r2 ", "2tr2 ", "r2t2 ", "2rt2 ", "r22t ", "2r2t "]
     replace: "󱤫"
-    word: true
 
-  - triggers: ["32", "23"]
+  - triggers: ["32 ", "23 "]
     replace: "󱤬"
-    word: true
 
-  - trigger: "q"
+  - trigger: "q "
     replace: "󱤭"
-    word: true
 
-  - trigger: "e3"
+  - trigger: "e3 "
     replace: "󱤮"
-    word: true
 
-  - trigger: "413"
+  - trigger: "413 "
     replace: "󱥺"
-    word: true
 
-  - triggers: ["tww", "wtw", "wwt"]
+  - triggers: ["tww ", "wtw ", "wwt "]
     replace: "󱤯"
-    word: true
 
-  - trigger: "e2w"
+  - trigger: "e2w "
     replace: "󱤰"
-    word: true
 
-  - trigger: "3e"
+  - trigger: "3e "
     replace: "󱤱"
-    word: true
 
-  - triggers: ["et", "2e2"]
+  - triggers: ["et ", "2e2 "]
     replace: "󱤲"
-    word: true
 
-  - triggers: ["5e", "e5"]
+  - triggers: ["5e ", "e5 "]
     replace: "󱤳"
-    word: true
 
-  - trigger: "we"
+  - trigger: "we "
     replace: "󱤴"
-    word: true
 
-  - trigger: "rer"
+  - trigger: "rer "
     replace: "󱤵"
-    word: true
 
-  - triggers: ["t2q", "2tq", "q2t", "qt2"]
+  - triggers: ["t2q ", "2tq ", "q2t ", "qt2 "]
     replace: "󱤶"
-    word: true
 
-  - triggers: ["e4r4r", "er4r4", "e4r"]
+  - triggers: ["e4r4r ", "er4r4 ", "e4r "]
     replace: "󱤷"
-    word: true
 
-  - triggers: ["32w2", "36"]
+  - triggers: ["32w2 ", "36 "]
     replace: "󱤸"
-    word: true
 
-  - triggers: ["ee3e", "e3ee", "eee3"]
+  - triggers: ["ee3e ", "e3ee ", "eee3 "]
     replace: "󱤹"
-    word: true
 
-  - trigger: "11"
+  - trigger: "11 "
     replace: "󱤺"
-    word: true
 
-  - trigger: "ete"
+  - trigger: "ete "
     replace: "󱤻"
-    word: true
 
-  - trigger: "www"
+  - trigger: "www "
     replace: "󱤼"
-    word: true
 
-  - triggers: ["d3", "3d"]
+  - triggers: ["d3 ", "3d "]
     replace: "󱥸"
-    word: true
 
-  - triggers: ["ww22", "22ww"]
+  - triggers: ["ww22 ", "22ww "]
     replace: "󱤽"
-    word: true
 
-  - triggers: ["t5t", "5t5"]
+  - triggers: ["t5t ", "5t5 "]
     replace: "󱤾"
-    word: true
 
-  - triggers: ["wr", "rw"]
+  - triggers: ["wr ", "rw "]
     replace: "󱤿"
-    word: true
 
-  - triggers: ["5ww", "ww5", "w5w"]
+  - triggers: ["5ww ", "ww5 ", "w5w "]
     replace: "󱥀"
-    word: true
 
-  - trigger: "w4"
+  - trigger: "w4 "
     replace: "󱥁"
-    word: true
 
-  - triggers: ["w2w2", "2w2w"]
+  - triggers: ["w2w2 ", "2w2w "]
     replace: "󱥂"
-    word: true
 
-  - triggers: ["w1w", "w12w"]
+  - triggers: ["w1w ", "w12w "]
     replace: "󱥃"
-    word: true
 
-  - trigger: "w3"
+  - trigger: "w3 "
     replace: "󱥄"
-    word: true
 
-  - triggers: ["554554", "455455"]
+  - triggers: ["554554 ", "455455 "]
     replace: "󱥅"
-    word: true
 
-  - trigger: "2e"
+  - trigger: "2e "
     replace: "󱥆"
-    word: true
 
-  - triggers: ["s2", "2s"]
+  - triggers: ["s2 ", "2s "]
     replace: "󱥇"
-    word: true
 
-  - triggers: ["d4r", "dr4"]
+  - triggers: ["d4r ", "dr4 "]
     replace: "󱥈"
-    word: true
 
-  - triggers: ["eq", "qe"]
+  - triggers: ["eq ", "qe "]
     replace: "󱥉"
-    word: true
 
-  - triggers: ["5wwt", "tww5", "5wtw", "tw5w", "w5wt", "wtw5"]
+  - triggers: ["5wwt ", "tww5 ", "5wtw ", "tw5w ", "w5wt ", "wtw5 "]
     replace: "󱥊"
-    word: true
 
-  - trigger: "444"
+  - trigger: "444 "
     replace: "󱥋"
-    word: true
 
-  - triggers: ["qf", "fq"]
+  - triggers: ["qf ", "fq "]
     replace: "󱥌"
-    word: true
 
-  - trigger: "w2"
+  - trigger: "w2 "
     replace: "󱥍"
-    word: true
 
-  - triggers: ["554", "455", "55t"]
+  - triggers: ["554 ", "455 ", "55t "]
     replace: "󱥎"
-    word: true
 
-  - triggers: ["r24r", "4rr2"]
+  - triggers: ["r24r ", "4rr2 "]
     replace: "󱥏"
-    word: true
 
-  - trigger: "2w2"
+  - trigger: "2w2 "
     replace: "󱥐"
-    word: true
 
-  - triggers: ["33w222", "w22233", "222w33"]
+  - triggers: ["33w222 ", "w22233 ", "222w33 "]
     replace: "󱥑"
-    word: true
 
-  - trigger: "s3"
+  - trigger: "s3 "
     replace: "󱥒"
-    word: true
 
-  - trigger: "s"
+  - trigger: "s "
     replace: "󱥓"
-    word: true
 
-  - trigger: "t"
+  - trigger: "t "
     replace: "󱥔"
-    word: true
 
-  - trigger: "deft"
+  - trigger: "deft "
     replace: "󱥕"
-    word: true
 
-  - trigger: "22"
+  - trigger: "22 "
     replace: "󱥖"
-    word: true
 
-  - triggers: ["3f", "f3"]
+  - triggers: ["3f ", "f3 "]
     replace: "󱥗"
-    word: true
 
-  - triggers: ["w2www", "2wwww", "22w22"]
+  - triggers: ["w2www ", "2wwww ", "22w22 "]
     replace: "󱥘"
-    word: true
 
-  - triggers: ["q3", "3q"]
+  - triggers: ["q3 ", "3q "]
     replace: "󱥙"
-    word: true
 
-  - triggers: ["ttw", "wttw"]
+  - triggers: ["ttw ", "wttw "]
     replace: "󱥚"
-    word: true
 
-  - triggers: ["w2ww", "2www"]
+  - triggers: ["w2ww ", "2www "]
     replace: "󱥛"
-    word: true
 
-  - trigger: "ee"
+  - trigger: "ee "
     replace: "󱥜"
-    word: true
 
-  - trigger: "f"
+  - trigger: "f "
     replace: "󱥝"
-    word: true
 
-  - trigger: "ew"
+  - trigger: "ew "
     replace: "󱥞"
-    word: true
 
-  - triggers: ["2w23", "y3"]
+  - triggers: ["2w23 ", "y3 "]
     replace: "󱥟"
-    word: true
 
-  - triggers: ["d333", "d33"]
+  - triggers: ["d333 ", "d33 "]
     replace: "󱥠"
-    word: true
 
-  - triggers: ["df", "fd"]
+  - triggers: ["df ", "fd "]
     replace: "󱥡"
-    word: true
 
-  - triggers: ["2133wwww", "133ww", "1wwww33", "133wwww", "1ww33"]
+  - triggers: ["2133wwww ", "133ww ", "1wwww33 ", "133wwww ", "1ww33 "]
     replace: "󱥢"
-    word: true
 
-  - triggers: ["44", "w4w"]
+  - triggers: ["44 ", "w4w "]
     replace: "󱥣"
-    word: true
 
-  - trigger: "ed"
+  - trigger: "ed "
     replace: "󱥤"
-    word: true
 
-  - triggers: ["2ww", "ww2"]
+  - triggers: ["2ww ", "ww2 "]
     replace: "󱥥"
-    word: true
 
-  - triggers: ["r3r", "rr3", "3rr"]
+  - triggers: ["r3r ", "rr3 ", "3rr "]
     replace: "󱥦"
-    word: true
 
-  - triggers: ["45", "54"]
+  - triggers: ["45 ", "54 "]
     replace: "󱥧"
-    word: true
 
-  - trigger: "2w"
+  - trigger: "2w "
     replace: "󱥨"
-    word: true
 
-  - trigger: "r22"
+  - trigger: "r22 "
     replace: "󱥩"
-    word: true
 
-  - triggers: ["5t5t", "t5t5"]
+  - triggers: ["5t5t ", "t5t5 "]
     replace: "󱥪"
-    word: true
 
-  - trigger: "ew2"
+  - trigger: "ew2 "
     replace: "󱥫"
-    word: true
 
-  - trigger: "ef"
+  - trigger: "ef "
     replace: "󱥬"
-    word: true
 
-  - triggers: ["rs", "sr"]
+  - triggers: ["rs ", "sr "]
     replace: "󱥭"
-    word: true
 
-  - trigger: "ww"
+  - trigger: "ww "
     replace: "󱥮"
-    word: true
 
-  - triggers: ["554e", "55te"]
+  - triggers: ["554e ", "55te "]
     replace: "󱥯"
-    word: true
 
-  - triggers: ["t23", "2t3"]
+  - triggers: ["t23 ", "2t3 "]
     replace: "󱥰"
-    word: true
 
-  - triggers: ["4r4", "44r4"]
+  - triggers: ["4r4 ", "44r4 "]
     replace: "󱥱"
-    word: true
 
-  - triggers: ["r24", "2r4"]
+  - triggers: ["r24 ", "2r4 "]
     replace: "󱥲"
-    word: true
 
-  - trigger: "w"
+  - trigger: "w "
     replace: "󱥳"
-    word: true
 
-  - triggers: ["rw33", "33rw"]
+  - triggers: ["rw33 ", "33rw "]
     replace: "󱥴"
-    word: true
 
-  - trigger: "wew"
+  - trigger: "wew "
     replace: "󱥵"
-    word: true
 
-  - trigger: "fw"
+  - trigger: "fw "
     replace: "󱥶"
-    word: true
 
-  - trigger: "tt"
+  - trigger: "tt "
     replace: "󱥷"
-    word: true
 
   # ku suli
-  - triggers: ["e22w", "ew22", "e2w2"]
+  - triggers: ["e22w ", "ew22 ", "e2w2 "]
     replace: "󱥾"
-    word: true
 
-  - triggers: ["rrrr", "4444"]
+  - triggers: ["rrrr ", "4444 "]
     replace: "󱥽"
-    word: true
 
-  - trigger: "ewww5rwww33"
+  - trigger: "ewww5rwww33 "
     replace: "󱦀"
-    word: true
 
-  - trigger: "dd"
+  - trigger: "dd "
     replace: "󱥼"
-    word: true
     
-  - trigger: "3w3"
+  - trigger: "3w3 "
     replace: "󱥻"
-    word: true
 
-  - triggers: ["eeer", "eere", "eree", "reee"]
+  - triggers: ["eeer ", "eere ", "eree ", "reee "]
     replace: "󱦡"
-    word: true
  
-  - triggers: ["5t5tw", "t5t5w", "wt5t5", "w5t5t"]
+  - triggers: ["5t5tw ", "t5t5w ", "wt5t5 ", "w5t5t "]
     replace: "󱥿"
-    word: true
     
-  - triggers: ["e4w", "4we"]
+  - triggers: ["e4w ", "4we "]
     replace: "󿫤"
-    word: true
 
-  - trigger: "w5"
+  - trigger: "w5 "
     replace: "󱦆"
-    word: true
   
-  - triggers: ["es", "52s"]
+  - triggers: ["es ", "52s "]
     replace: "󱦁"
-    word: true
 
-  - triggers: ["w3w", "3ww"]
+  - triggers: ["w3w ", "3ww "]
     replace: "󱦂"
-    word: true
 
-  - triggers: ["wwr", "rww"]
+  - triggers: ["wwr ", "rww "]
     replace: "󱦃"
-    word: true
 
-  - triggers: ["ef2", "fe2"]
+  - triggers: ["ef2 ", "fe2 "]
     replace: "󱦄"
-    word: true
 
-  - trigger: "5t53"
+  - trigger: "5t53 "
     replace: "󱦅"
-    word: true
 
-  - triggers: ["5wwt2", "tww52", "5wtw2", "tw5w2", "w5wt2", "wtw52"]
+  - triggers: ["5wwt2 ", "tww52 ", "5wtw2 ", "tw5w2 ", "w5wt2 ", "wtw52 "]
     replace: "󱦇"
-    word: true
   
-  - triggers: ["d423", "d42eft"]
+  - triggers: ["d423 ", "d42eft "]
     replace: "󱦈"
-    word: true
 
-  - triggers: ["ff2", "2ff", "f2f"]
+  - triggers: ["ff2 ", "2ff ", "f2f "]
     replace: "󿬯"
-    word: true
 
   # (select) ku lili
-  - triggers: ["e22f", "fe22", "ef22"]
+  - triggers: ["e22f ", "fe22 ", "ef22 "]
     replace: "󿫀"
-    word: true
 
-  - triggers: ["e2wr2", "ew2r2", "e2w2r", "ew22r", "r2e2w", "r2ew2", "2re2w", "2rew2"]
+  - triggers: ["e2wr2 ", "ew2r2 ", "e2w2r ", "ew22r ", "r2e2w ", "r2ew2 ", "2re2w ", "2rew2 "]
     replace: "󿫁"
-    word: true
 
-  - triggers: ["rrr444", "rrrr4444"]
+  - triggers: ["rrr444 ", "rrrr4444 "]
     replace: "󿫃"
-    word: true
 
-  - triggers: ["w2wt5w333", "w2w333t5w", "w2wwt5333", "w2ww333t5"]
+  - triggers: ["w2wt5w333 ", "w2w333t5w ", "w2wwt5333 ", "w2ww333t5 "]
     replace: "󿫄"
-    word: true
 
-  - triggers: ["r2eee", "2reee", "eeer2", "eee2r"]
+  - triggers: ["r2eee ", "2reee ", "eeer2 ", "eee2r "]
     replace: "󿫈"
-    word: true
 
-  - triggers: ["w22", "22w"]
+  - triggers: ["w22 ", "22w "]
     replace: "󱦠"
-    word: true
 
-  - trigger: "w21"
+  - trigger: "w21 "
     replace: "󿫽"
-    word: true
 
-  - trigger: "wr4"
+  - trigger: "wr4 "
     replace: "󱦣"
-    word: true
 
-  - triggers: ["11r2", "112r", "r211", "2r11"]
+  - triggers: ["11r2 ", "112r ", "r211 ", "2r11 "]
     replace: "󿫊"
-    word: true
 
-  - trigger: "wtt"
+  - trigger: "wtt "
     replace: "󿫋"
-    word: true


### PR DESCRIPTION
from new commits:
> Revert change in *[a previous]* commit that set 'word' property to true, which introduced undesired word seperators (spaces, commas, or newlines) after expanded sitelen pona UCSUR characters).
Appended ' ' (Space) to all triggers, which replaces the input AND the space being used as a word separator with the trigger's expansion.

> added instructions to README to enable toggling Espanso on/off 